### PR TITLE
Tagresources

### DIFF
--- a/.ci/scripts/SetResource.ps1
+++ b/.ci/scripts/SetResource.ps1
@@ -1,0 +1,81 @@
+param (
+    [string] $resourceGroupName,
+    [string] $tagId, 
+    [string] $deploymentId
+)
+
+$projectTags = New-Object 'System.Collections.Generic.Dictionary[String,String]'
+$projectTags.Add($tagId, $deploymentId)
+
+function UpdateLoop
+{
+    param( [int]$maxIterations, $resource )
+
+    $success = $false
+    $iterator = 1
+
+    while( ($success -eq $false) -and ($iterator -le $maxIterations))
+    {
+        try 
+        {
+            if($resource.type -eq "Microsoft.MachineLearningServices/workspaces")
+            {
+                Set-AzResource -ResourceId $resource.Id -Tag $resource.Tags -ApiVersion 2019-06-01 -Force
+            }
+            else
+            {
+                Set-AzResource -ResourceId $resource.Id -Tag $resource.Tags -Force
+            }
+
+            $success = $true
+            break
+        }
+        catch 
+        {
+            Write-Host("Failed to write resource update - ")
+            Write-Host($_.Exception.Message)
+        }
+    }
+
+    if($success -eq $false)
+    {
+        throw "Failed to update resources"
+    }
+}
+
+
+function Update-GroupResources 
+{
+    param( [string]$resGroup, $tags )
+    Write-Host("*************** Updating resources in " + $resGroup)
+    $resources = Get-AzResource -ResourceGroupName $resGroup 
+    $resources | ForEach-Object {
+        if($_.Tags -eq $null)
+        {
+            $_.Tags = $projectTags
+        }
+        else {
+            $rsrc = $_
+            $tags.Keys | Foreach {
+                $rsrc.Tags[$_] = $tags[$_] 
+            }
+        }
+    }
+    $resources | ForEach-Object {
+        Write-Host("*************** Updating resource " + $_.Id)
+        UpdateLoop -maxIterations 3 -resource $_
+    }
+}
+
+
+Write-Host("RG - " + $resourceGroupName)
+Write-Host("TAG - " + $tagId)
+Write-Host("VAL - " + $deploymentId)
+
+Update-GroupResources -resGroup $resourceGroupName -tags $projectTags
+
+$clusterResources = Get-AzResource -ResourceType "Microsoft.ContainerService/managedClusters" -ResourceGroupName $resourceGroupName -ExpandProperties
+foreach($cluster in $clusterResources)
+{
+    Update-GroupResources -resGroup $cluster.Properties.nodeResourceGroup -tags $projectTags
+}

--- a/.ci/scripts/SetResource.ps1
+++ b/.ci/scripts/SetResource.ps1
@@ -34,6 +34,7 @@ function UpdateLoop
         {
             Write-Host("Failed to write resource update - ")
             Write-Host($_.Exception.Message)
+            Start-Sleep -Seconds 5
         }
     }
 

--- a/.ci/steps/deploy_steps.yml
+++ b/.ci/steps/deploy_steps.yml
@@ -67,50 +67,9 @@ steps:
 - task: AzurePowerShell@4
   inputs:
     azureSubscription: ${{parameters.azureSubscription}}
-    ScriptType: 'InlineScript'
-    FailOnStandardError: true
-    azurePowerShellVersion: '4.157.4'
-    Inline: |      
-     $resourceGroupName = "${{parameters.azureresourcegroup}}"
-
-     $projectTags = New-Object 'System.Collections.Generic.Dictionary[String,String]'
-     $projectTags.Add("deployment-id", "${{parameters.deploymentguidtag}}")
-
-     function Update-GroupResources 
-     {
-         param( [string]$resGroup, $tags )
-         Write-Host("*************** Updating resources in " + $resGroup)
-         $resources = Get-AzResource -ResourceGroupName $resGroup 
-         $resources | ForEach-Object {
-             if($_.Tags -eq $null)
-             {
-                 $_.Tags = $projectTags
-             }
-             else {
-                 $rsrc = $_
-                 $tags.Keys | Foreach {
-                     $rsrc.Tags[$_] = $tags[$_] 
-                 }
-             }
-         }
-         $resources | ForEach-Object {
-             Write-Host("*************** Updating resource " + $_.Id)
-             if($_.type -eq "Microsoft.MachineLearningServices/workspaces")
-             {
-                 Set-AzResource -ResourceId $_.Id -Tag $_.Tags -ApiVersion 2019-06-01 -Force
-             }
-             else
-             {
-                 Set-AzResource -ResourceId $_.Id -Tag $_.Tags -Force
-             }
-         }
-     }
-
-     Update-GroupResources -resGroup $resourceGroupName -tags $projectTags
-
-     $clusterResources = Get-AzResource -ResourceType "Microsoft.ContainerService/managedClusters" -ResourceGroupName $resourceGroupName -ExpandProperties
-     foreach($cluster in $clusterResources)
-     {
-         Update-GroupResources -resGroup $cluster.Properties.nodeResourceGroup -tags $projectTags
-     }   
-    displayName: 'Tag All Resources'
+    ScriptType: 'FilePath'
+    ScriptPath: '../scripts/SetResource.ps1'
+    ScriptArguments: '-resourceGroupName ''${{parameters.azureresourcegroup}}'' -tagId ''deployment-id'' -deploymentId ''${{parameters.deploymentguidtag}}'''
+    azurePowerShellVersion: 'LatestVersion'
+  displayName: 'Tag All Resources'
+  


### PR DESCRIPTION
Moves the tagging of resources to a script. Script is more resilient in that it will attempt multiple retries in an attempt to overcome the TransientError seen when setting the MachineLearningWorkspace tags. 

Iteration attempts can be modified. A sleep is put in after each exception of 5 seconds in an attempt to wait out the ETag conflict. 