### PR TITLE
Fix bugs in Azure ML CI helper scripts (aml_creation.py, aml_attach_blob.py)

### DIFF
--- a/.ci/scripts/aml_attach_blob.py
+++ b/.ci/scripts/aml_attach_blob.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import azureml.core
-from azureml.core import Workspace
+from azureml.core import Workspace, Datastore
 from dotenv import set_key, get_key, find_dotenv
 from pathlib import Path
 from AIHelpers.utilities import get_auth
@@ -13,11 +13,11 @@ def main(argv):
      opts, args = getopt.getopt(argv,"hs:rg:wn:wr:dsn:cn:an:ak:drg:",
       ["subscription_id=","resource_group=","workspace_name=", "workspace_region=","blob_datastore_name=","container_name=","account_name=","account_key=","datastore_rg="])
   except getopt.GetoptError:
-     print 'aml_creation.py -s <subscription_id> -rg <resource_group> -wn <workspace_name> -wr <workspace_region>'
+     print 'aml_attach_blob.py -s <subscription_id> -rg <resource_group> -wn <workspace_name> -wr <workspace_region> -dsn <blob_datastore_name> -cn <container_name> -an <account_name> -ak <account_key> -drg <datastore_rg>'
      sys.exit(2)
   for opt, arg in opts:
      if opt == '-h':
-        print 'aml_creation.py -s <subscription_id> -rg <resource_group> -wn <workspace_name> -wr <workspace_region>'
+        print 'aml_attach_blob.py -s <subscription_id> -rg <resource_group> -wn <workspace_name> -wr <workspace_region> -dsn <blob_datastore_name> -cn <container_name> -an <account_name> -ak <account_key> -drg <datastore_rg>'
         sys.exit()
      elif opt in ("-s", "--subscription_id"):
         subscription_id = arg
@@ -28,36 +28,38 @@ def main(argv):
      elif opt in ("-wr", "--workspace_region"):
         workspace_region = arg
      elif opt in ("-dsn", "--blob_datastore_name"):
-        workspace_region = arg
+        blob_datastore_name = arg
      elif opt in ("-cn", "--container_name"):
-        workspace_region = arg
+        container_name = arg
      elif opt in ("-an", "--account_name"):
-        workspace_region = arg
+        account_name = arg
      elif opt in ("-ak", "--account_key"):
-        workspace_region = arg
+        account_key = arg
      elif opt in ("-drg", "--datastore_rg"):
-        workspace_region = arg
-        
-    env_path = find_dotenv()
-    if env_path == "":
-        Path(".env").touch()
-        env_path = find_dotenv()
+        datastore_rg = arg
 
-    ws = Workspace.create(
-      name=workspace_name,
-      subscription_id=subscription_id,
-      resource_group=resource_group,
-      location=workspace_region,
-      create_resource_group=True,
-      auth=get_auth(env_path),
-      exist_ok=True,
-    )
-    blob_datastore = Datastore.register_azure_blob_container(workspace=ws, 
-                                                         datastore_name=blob_datastore_name, 
-                                                         container_name=container_name, 
-                                                         account_name=account_name,
-                                                         account_key=account_key,
-                                                         resource_group=datastore_rg)
+  env_path = find_dotenv()
+  if env_path == "":
+      Path(".env").touch()
+      env_path = find_dotenv()
+
+  ws = Workspace.create(
+    name=workspace_name,
+    subscription_id=subscription_id,
+    resource_group=resource_group,
+    location=workspace_region,
+    create_resource_group=True,
+    auth=get_auth(env_path),
+    exist_ok=True,
+  )
+  blob_datastore = Datastore.register_azure_blob_container(
+    workspace=ws,
+    datastore_name=blob_datastore_name,
+    container_name=container_name,
+    account_name=account_name,
+    account_key=account_key,
+    resource_group=datastore_rg,
+  )
 
 if __name__ == "__main__":
   print("AML SDK Version:", azureml.core.VERSION)

--- a/.ci/scripts/aml_creation.py
+++ b/.ci/scripts/aml_creation.py
@@ -26,28 +26,22 @@ def main(argv):
         workspace_name = arg
      elif opt in ("-wr", "--workspace_region"):
         workspace_region = arg
-        
-    env_path = find_dotenv()
-    if env_path == "":
-        Path(".env").touch()
-        env_path = find_dotenv()
 
-    ws = Workspace.create(
-      name=workspace_name,
-      subscription_id=subscription_id,
-      resource_group=resource_group,
-      location=workspace_region,
-      create_resource_group=True,
-      auth=get_auth(env_path),
-      exist_ok=True,
-    )
+  env_path = find_dotenv()
+  if env_path == "":
+      Path(".env").touch()
+      env_path = find_dotenv()
+
+  ws = Workspace.create(
+    name=workspace_name,
+    subscription_id=subscription_id,
+    resource_group=resource_group,
+    location=workspace_region,
+    create_resource_group=True,
+    auth=get_auth(env_path),
+    exist_ok=True,
+  )
 
 if __name__ == "__main__":
   print("AML SDK Version:", azureml.core.VERSION)
   main(sys.argv[1:])
-  
-  # Azure resources
-  subscription_id = "{{cookiecutter.subscription_id}}"
-  resource_group = "{{cookiecutter.resource_group}}"  
-  workspace_name = "{{cookiecutter.workspace_name}}"  
-  workspace_region = "{{cookiecutter.workspace_region}}"


### PR DESCRIPTION
### Summary

This PR fixes several genuine bugs in the Azure ML CI helper scripts under `.ci/scripts/`.

#### `.ci/scripts/aml_attach_blob.py`

1. **Copy-paste bug in CLI argument parsing** — all five datastore options (`-dsn/--blob_datastore_name`, `-cn/--container_name`, `-an/--account_name`, `-ak/--account_key`, `-drg/--datastore_rg`) were assigned to `workspace_region`. The variables actually consumed by `Datastore.register_azure_blob_container(...)` were therefore never set, which would raise a `NameError` at runtime. Each option now stores into its own variable.
2. **Missing import** — `Datastore` is used but was never imported from `azureml.core`, which would also raise `NameError`.
3. **Indentation bug** — the workspace/datastore creation block was indented inside the `for opt, arg in opts:` loop, so the creation logic ran once per CLI option instead of once after parsing completed.
4. **Copy-paste usage string** — the usage/help text referenced `aml_creation.py` instead of `aml_attach_blob.py`.

#### `.ci/scripts/aml_creation.py`

1. **Indentation bug** — same issue: `Workspace.create(...)` was indented inside the argument-parsing `for` loop and executed once per option.
2. Removed leftover cookiecutter template placeholders (`{{cookiecutter.*}}`) that were never substituted.

### Verification

- Simulated the fixed `getopt` parsing (same option tables) and confirmed each long option now assigns to the correct variable.
- Confirmed with `tokenize` that the workspace/datastore creation block sits at function-body level (after the parsing loop) in both scripts.

These scripts are referenced by the Azure DevOps templates (`creation_step.yml`, `deploy_steps.yml`). No behavior change beyond fixing the bugs.
