### PR TITLE
Fix invalid JSON Schema in listing_config_schema.json

### DIFF
--- a/.ci/listing_config_schema.json
+++ b/.ci/listing_config_schema.json
@@ -59,19 +59,19 @@
           "maxLength": 3
         },
         "listing_contacts"   : {
-          "type": "list"
+          "type": "array"
         },
         "listing_uris"       : {
-          "type": "list"
+          "type": "array"
         },
         "listing_logos"      : {
-          "type": "list"
+          "type": "array"
         },
         "listing_screenshots": {
-          "type": "list"
+          "type": "array"
         },
         "listing_videos"     : {
-          "type": "list"
+          "type": "array"
         }
       },
       "required"   : [
@@ -120,207 +120,99 @@
       "items"      : {
         "type"      : "object",
         "properties": {
-          "type" : "array",
-          "items": {
+          "plan_listing"            : {
             "type"      : "object",
             "properties": {
-              "plan_listing"            : {
-                "type"      : "object",
-                "properties": {
-                  "title"      : {
-                    "type": "string"
-                  },
-                  "summary"    : {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  }
-                }
+              "title"      : {
+                "type": "string"
               },
-              "pricing_and_availability": {
-                "type"      : "object",
-                "properties": {
-                  "visibility"                 : {
-                    "type": "string",
-                    "enum": [
-                      "private",
-                      "public"
-                    ]
+              "summary"    : {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          },
+          "pricing_and_availability": {
+            "type"      : "object",
+            "properties": {
+              "visibility"                 : {
+                "type": "string",
+                "enum": [
+                  "private",
+                  "public"
+                ]
+              },
+              "azure_private_subscriptions": {
+                "type" : "array",
+                "items": {
+                  "type"      : "object",
+                  "properties": {
+                    "ID"         : {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    }
                   },
-                  "azure_private_subscriptions": {
-                    "type" : "array",
-                    "items": {
-                      "type"      : "object",
-                      "properties": {
-                        "ID"         : {
-                          "type": "string"
-                        },
-                        "Description": {
-                          "type": "string"
-                        }
-                      },
-                      "required"  : [
-                        "ID"
+                  "required"  : [
+                    "ID"
+                  ]
+                }
+              }
+            }
+          },
+          "technical_configuration" : {
+            "type"      : "object",
+            "properties": {
+              "version"               : {
+                "type": "string"
+              },
+              "allowedCustomerActions": {
+                "type"     : "array",
+                "items"    : {
+                  "type": "string"
+                },
+                "maxLength": 1
+              },
+              "allowedDataActions"    : {
+                "type"     : "array",
+                "items"    : {
+                  "type": "string"
+                },
+                "maxLength": 1
+              },
+              "tenant_id"             : {
+                "type": "string"
+              },
+              "authorizations"        : {
+                "type"     : "array",
+                "items"    : {
+                  "type"      : "object",
+                  "properties": {
+                    "id"  : {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string",
+                      "enum": [
+                        "Owner",
+                        "Contributor"
                       ]
                     }
                   }
-                }
+                },
+                "minLength": 1,
+                "maxLength": 10
               },
-              "technical_configuration" : {
-                "type"      : "object",
-                "properties": {
-                  "version"               : {
-                    "type": "string"
-                  },
-                  "allowedCustomerActions": {
-                    "type"     : "array",
-                    "items"    : {
-                      "type": "string"
-                    },
-                    "maxLength": 1
-                  },
-                  "allowedDataActions"    : {
-                    "type"     : "array",
-                    "items"    : {
-                      "type": "string"
-                    },
-                    "maxLength": 1
-                  },
-                  "tenant_id"             : {
-                    "type": "string"
-                  },
-                  "authorizations"        : {
-                    "type"     : "array",
-                    "items"    : {
-                      "type"      : "object",
-                      "properties": {
-                        "id"  : {
-                          "type": "string"
-                        },
-                        "role": {
-                          "type": "string",
-                          "enum": [
-                            "Owner",
-                            "Contributor"
-                          ]
-                        }
-                      }
-                    },
-                    "minLength": 1,
-                    "maxLength": 10
-                  },
-                  "policy_settings"       : {
-                    "type": "array"
-                  }
-                },
-                "required"  : [
-                  "version"
-                ]
-              }
-            }
-          }
-        }
-      },
-      "properties" : {
-        "type" : "array",
-        "items": {
-          "type"      : "object",
-          "properties": {
-            "plan_listing"            : {
-              "type"      : "object",
-              "properties": {
-                "title"      : {
-                  "type": "string"
-                },
-                "summary"    : {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
+              "policy_settings"       : {
+                "type": "array"
               }
             },
-            "pricing_and_availability": {
-              "type"      : "object",
-              "properties": {
-                "visibility"                 : {
-                  "type": "string",
-                  "enum": [
-                    "private",
-                    "public"
-                  ]
-                },
-                "azure_private_subscriptions": {
-                  "type" : "array",
-                  "items": {
-                    "type"      : "object",
-                    "properties": {
-                      "ID"         : {
-                        "type": "string"
-                      },
-                      "Description": {
-                        "type": "string"
-                      }
-                    },
-                    "required"  : [
-                      "ID"
-                    ]
-                  }
-                }
-              }
-            },
-            "technical_configuration" : {
-              "type"      : "object",
-              "properties": {
-                "version"               : {
-                  "type": "string"
-                },
-                "allowedCustomerActions": {
-                  "type"     : "array",
-                  "items"    : {
-                    "type": "string"
-                  },
-                  "maxLength": 1
-                },
-                "allowedDataActions"    : {
-                  "type"     : "array",
-                  "items"    : {
-                    "type": "string"
-                  },
-                  "maxLength": 1
-                },
-                "tenant_id"             : {
-                  "type": "string"
-                },
-                "authorizations"        : {
-                  "type"     : "array",
-                  "items"    : {
-                    "type"      : "object",
-                    "properties": {
-                      "id"  : {
-                        "type": "string"
-                      },
-                      "role": {
-                        "type": "string",
-                        "enum": [
-                          "Owner",
-                          "Contributor"
-                        ]
-                      }
-                    }
-                  },
-                  "minLength": 1,
-                  "maxLength": 10
-                },
-                "policy_settings"       : {
-                  "type": "array"
-                }
-              },
-              "required"  : [
-                "version"
-              ]
-            }
+            "required"  : [
+              "version"
+            ]
           }
         }
       }


### PR DESCRIPTION
### Summary

`.ci/listing_config_schema.json` declares `$schema: https://json-schema.org/draft/2020-12/schema`, but it was **not valid** against that meta-schema. Validating with the `jsonschema` library surfaced 21 meta-schema violations, from two distinct problems:

#### 1. `"type": "list"` is not a valid JSON Schema type (`offer_listing`)
The `listing_contacts`, `listing_uris`, `listing_logos`, `listing_screenshots` and `listing_videos` fields used `"type": "list"`. `list` is not a valid JSON Schema type — these are collections, so the correct type is `"array"`.

#### 2. `plan_overview` was structurally malformed
- `items.properties` contained a nested `{"type": "array", "items": {...}}` wrapper that held the actual plan object, so the property names `type`/`items` were treated as schema properties and the real plan properties were never applied.
- A duplicate copy of the plan schema was also placed at the array level under a `properties` keyword, which is meaningless on an `array` schema and was silently ignored.

The real plan properties (`plan_listing`, `pricing_and_availability`, `technical_configuration`) are now declared directly under `items.properties`, and the duplicated array-level block is removed.

### Verification (with the `jsonschema` library, draft 2020-12)

| Check | Before | After |
|---|---|---|
| Valid against declared meta-schema | **INVALID** (21 violations) | **VALID** (0 violations) |
| Accepts a realistic configuration instance | – | ✓ |
| Rejects malformed plan data (e.g. `plan_listing: 123`) | **silently accepted** | ✓ rejected |

This means the schema now actually constrains the plan data it was meant to describe instead of accepting anything.
