### PR TITLE
Fix broken Cosmos DB ARM deployment template

### DIFF
--- a/AzureDeployment/CosmosDB/cosmosdb.json
+++ b/AzureDeployment/CosmosDB/cosmosdb.json
@@ -40,10 +40,11 @@
         ],
         "databaseAccountOfferType": "Standard",
         "keyVaultKeyUri": "[parameters('keyVaultKeyUri')]"
+      }
     },
     {
-      "name": "[parameters('databaseName')]",
-      "type": "Microsoft.DocumentDB/sqlDatabases",
+      "name": "[concat(parameters('accountName'), '/', parameters('databaseName'))]",
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
       "apiVersion": "2020-04-01",
       "dependsOn": [
         "[parameters('accountName')]"
@@ -56,13 +57,13 @@
           "throughput": 400
         }
       }
-    }
+    },
     {
-      "name": "[parameters('containerName')]",
-      "type": "Microsoft.DocumentDB/containers",
+      "name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', parameters('containerName'))]",
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
       "apiVersion": "2020-04-01",
       "dependsOn": [
-        "[parameters('databaseName')]"
+        "[concat(parameters('accountName'), '/', parameters('databaseName'))]"
       ],
       "properties": {
         "resource": {


### PR DESCRIPTION
### Summary

`AzureDeployment/CosmosDB/cosmosdb.json` was **not valid JSON**, so the template could not be parsed — let alone deployed — by Azure Resource Manager. It has been broken since it was added in PR #18.

Three problems:

1. **Missing closing brace** — the `Microsoft.DocumentDB/databaseAccounts` resource was never closed, so `json.load` fails immediately (`Expecting property name enclosed in double quotes: line 44`).
2. **Missing comma** — the database and container resources were not separated by a comma.
3. **Incorrect child-resource type paths** — the database and container were declared as top-level resources but with the wrong types (`Microsoft.DocumentDB/sqlDatabases`, `Microsoft.DocumentDB/containers`). As top-level child resources they must use the full parent path (`Microsoft.DocumentDB/databaseAccounts/sqlDatabases` and `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers`) and their `name` must be prefixed with the parent resource name. The container's `dependsOn` was updated to reference the full database resource name.

### Verification

- `json.load` now succeeds — the file is valid JSON.
- Every resource uses the correct provider type path and parent-prefixed `name`, matching the documented Cosmos DB ARM pattern.
- The rest of the template (parameters, properties, outputs) is unchanged.
