### PR TITLE
Remove duplicate nest_asyncio dependency in environment.yml

### DIFF
--- a/.ci/environment.yml
+++ b/.ci/environment.yml
@@ -23,7 +23,6 @@ dependencies:
     - matplotlib==3.1.1
     - nest_asyncio>=0.9.10
     - nbconvert==5.4.1                
-    - nest_asyncio>=0.9.10
     - papermill==0.19.1
     - Pillow==6.1.0
     - prompt-toolkit>=2.0.7


### PR DESCRIPTION
## Summary

\.ci/environment.yml\ lists \
est_asyncio>=0.9.10\ twice consecutively in the pip dependencies section (a copy/paste artifact). Duplicate entries in the same section are meaningless and error-prone when versions diverge, so this removes the redundant second line.

No functional change — the version constraint is preserved and the file still parses as valid YAML.