### PR TITLE
Fix undefined 'notebook' parameter in azpapermill_iterator template

### DIFF
--- a/.ci/steps/azpapermill_iterator.yml
+++ b/.ci/steps/azpapermill_iterator.yml
@@ -40,7 +40,7 @@ steps:
       source activate ${{parameters.conda}}
       export PYTHONPATH=${{parameters.python_path}}:${PYTHONPATH}      
       cd ${{parameters.location}}
-      echo Execute ${{parameters.notebook}}
+      echo Execute ${{parameters.notebooks}}
       for notebook in ${{parameters.notebooks}}; do papermill $notebook output.ipynb \
         --log-output \
         --no-progress-bar \


### PR DESCRIPTION
## Summary

`.ci/steps/azpapermill_iterator.yml` references `${{parameters.notebook}}` (singular) in its inline script, but the template declares `notebooks:` (plural) in its own `parameters:` block, and the only caller (`.ci/steps/ADOTrainDeployAMLJob.yml`) passes `notebooks:`.

Referencing an undeclared template parameter makes Azure Pipelines template expansion fail, so this template cannot compile. The fix aligns the `echo` statement with the rest of the script, which already loops over `${{parameters.notebooks}}`.

## Verification

- The sibling template `.ci/steps/azpapermill.yml` declares `notebook:` (singular) and correctly uses `${{parameters.notebook}}` everywhere — the plural/singular split here is purely a copy/paste artifact.
- Bug confirmed present on upstream `microsoft/AI` master.
- File still parses as valid YAML.
