### PR TITLE
Remove print(key) that leaks secret value to pipeline logs

### DIFF
--- a/.ci/scripts/set_secret.py
+++ b/.ci/scripts/set_secret.py
@@ -30,7 +30,6 @@ if __name__ == "__main__":
     kv_endpoint = "https://t3scriptkeyvault.vault.azure.net/"
     args = parse_args()
     key = os.getenv("storage_conn_string")
-    print(key)
     message = set_secret(kv_endpoint, args.secretName, key)
 
     print(message)


### PR DESCRIPTION
## Summary

`.ci/scripts/set_secret.py` prints the raw value of `storage_conn_string` (line 33: `print(key)`) to stdout before storing it in Azure Key Vault. Because the script is invoked by `.ci/steps/deploy_steps.yml:65` and `.ci/steps/deploy_steps_v2.yml:77`, the secret value is captured in the Azure DevOps pipeline build log — visible to anyone with access to the run.

The `print()` is debug output; the function's own return message (`print(message)` on line 36) already confirms success. Removing the single line eliminates the leak with no change to the script's function.

## Verification

- Script syntax validated with `py_compile`.
- The only callers pass `-n <key-name>` via the inline script in `deploy_steps.yml`; the removed line is standalone with no downstream dependency.
- Bug confirmed present on upstream `microsoft/AI` master.
