### PR TITLE
Declare missing conda parameter in deploy_steps_v2 template

### DIFF
--- a/.ci/steps/deploy_steps_v2.yml
+++ b/.ci/steps/deploy_steps_v2.yml
@@ -19,6 +19,7 @@ parameters:
   location: "" #Root Dir of Project
   python_path: "" #Root Dir of Python Env
   python_secret_root: "./"
+  conda: 'deployment_aml'
 
 steps:
 


### PR DESCRIPTION
## Summary

`.ci/steps/deploy_steps_v2.yml` references `${{parameters.conda}}` in two places:

- **Line 40:** passed to `cleanuptask.yml` as the conda environment name.
- **Line 75:** used as `source activate ${{parameters.conda}}` to activate the environment before installing packages and running `set_secret.py`.

However, `conda` was never declared in the template's `parameters:` block (lines 1-21). An undeclared parameter resolves to an empty string at compile time, so `source activate` runs with no environment name and fails.

The same file already hardcodes `conda: deployment_aml` when calling `deploy_notebook_steps.yml` on line 68, confirming the intended default. The fix adds the missing declaration with that value.

## Verification

- YAML validates; `conda` now appears in the parsed parameters dict.
- Bug confirmed present on upstream `microsoft/AI` master.
- `cleanuptask.yml` accepts a `conda` parameter (declared with default `MLAKSDeployAML`) — passing the explicit value overrides it correctly.
