### PR TITLE
Fix infinite retry loop in SetResource.ps1 (missing $iterator increment)

### DIFF
--- a/.ci/scripts/SetResource.Tests.ps1
+++ b/.ci/scripts/SetResource.Tests.ps1
@@ -1,0 +1,71 @@
+# Pester tests for SetResource.ps1.
+#
+# Run with:
+#   Install-Module Pester -Scope CurrentUser -Force
+#   Invoke-Pester .ci/scripts/SetResource.Tests.ps1
+
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot 'SetResource.ps1'
+
+    # The Az cmdlets are not installed in CI, and these tests must not touch Azure.
+    # Declare stubs so Pester has something to mock.
+    function Get-AzResource {
+        param($ResourceGroupName, $ResourceType, [switch]$ExpandProperties)
+    }
+    function Set-AzResource {
+        param($ResourceId, $Tag, $ApiVersion, [switch]$Force)
+    }
+}
+
+Describe 'UpdateLoop' {
+    BeforeEach {
+        # Returning no resources keeps the script's top-level tagging pass a no-op,
+        # so dot-sourcing only imports the functions.
+        Mock Get-AzResource { @() }
+        Mock Start-Sleep { }
+
+        . $script:ScriptPath -resourceGroupName 'rg' -tagId 'tag' -deploymentId 'dep'
+
+        $script:resource = [pscustomobject]@{
+            Id   = '/subscriptions/x/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/s'
+            Tags = @{ tag = 'dep' }
+            type = 'Microsoft.Storage/storageAccounts'
+        }
+    }
+
+    It 'gives up after maxIterations when Set-AzResource keeps failing' {
+        # Fail well past the retry budget, then start succeeding. A loop that does not
+        # count its attempts therefore still terminates -- and fails on the assertions
+        # below rather than hanging the test run forever.
+        $script:attempts = 0
+        Mock Set-AzResource {
+            $script:attempts++
+            if ($script:attempts -le 20) { throw 'persistent failure' }
+        }
+
+        { UpdateLoop -maxIterations 3 -resource $script:resource } |
+            Should -Throw 'Failed to update resources'
+
+        $script:attempts | Should -Be 3
+    }
+
+    It 'stops retrying as soon as Set-AzResource succeeds' {
+        $script:attempts = 0
+        Mock Set-AzResource {
+            $script:attempts++
+            if ($script:attempts -lt 2) { throw 'transient failure' }
+        }
+
+        { UpdateLoop -maxIterations 3 -resource $script:resource } | Should -Not -Throw
+
+        $script:attempts | Should -Be 2
+    }
+
+    It 'does not retry when the first attempt succeeds' {
+        Mock Set-AzResource { }
+
+        { UpdateLoop -maxIterations 3 -resource $script:resource } | Should -Not -Throw
+
+        Should -Invoke Set-AzResource -Times 1 -Exactly
+    }
+}

--- a/.ci/scripts/SetResource.ps1
+++ b/.ci/scripts/SetResource.ps1
@@ -34,6 +34,7 @@ function UpdateLoop
         {
             Write-Host("Failed to write resource update - ")
             Write-Host($_.Exception.Message)
+            $iterator++
             Start-Sleep -Seconds 5
         }
     }


### PR DESCRIPTION
### Problem

`UpdateLoop` in `.ci/scripts/SetResource.ps1` is meant to retry a failing `Set-AzResource` call a bounded number of times:

```powershell
$success = $false
$iterator = 1

while( ($success -eq $false) -and ($iterator -le $maxIterations))
{
    try
    {
        ...
        $success = $true
        break
    }
    catch
    {
        Write-Host("Failed to write resource update - ")
        Write-Host($_.Exception.Message)
        Start-Sleep -Seconds 5
    }
}

if($success -eq $false)
{
    throw "Failed to update resources"
}
```

`$iterator` is initialized to `1` but is **never incremented**. When `Set-AzResource` keeps failing, `$success` stays `$false` and `$iterator` stays `1`, so the guard `($iterator -le $maxIterations)` is always true.

Consequences:

- The retry budget the caller passes (`UpdateLoop -maxIterations 3 -resource $_`) is ignored.
- A resource that can never be tagged (deleted mid-run, insufficient permissions, a provider that rejects the tag) makes the loop spin forever, sleeping 5 seconds and printing the same error each time, until the pipeline job hits its own timeout.
- The `throw "Failed to update resources"` below the loop is unreachable on persistent failure, so a genuine failure is reported as a hung/timed-out job instead of a clear error.

### Fix

Increment `$iterator` in the `catch` block, so the loop honors `-maxIterations` and a persistent failure exits via the existing `throw`.

```diff
             Write-Host($_.Exception.Message)
+            $iterator++
             Start-Sleep -Seconds 5
```

One line changed; no behavior change on the success path (that path still `break`s on the first successful call).
